### PR TITLE
Harden type/data model consistency for chatrooms and realtime events

### DIFF
--- a/packages/webapp/drizzle/0001_type_hardening.sql
+++ b/packages/webapp/drizzle/0001_type_hardening.sql
@@ -1,0 +1,13 @@
+ALTER TABLE "chatrooms"
+  ALTER COLUMN "is_private" TYPE boolean
+  USING CASE
+    WHEN "is_private" IN ('1', 'true', 't', 'yes', 'y', 'on') THEN true
+    ELSE false
+  END,
+  ALTER COLUMN "is_private" SET DEFAULT false,
+  ALTER COLUMN "is_private" SET NOT NULL;
+
+--> statement-breakpoint
+ALTER TABLE "chatroom_invites"
+  ALTER COLUMN "max_uses" TYPE integer
+  USING NULLIF(regexp_replace("max_uses", '[^0-9-]', '', 'g'), '')::integer;

--- a/packages/webapp/drizzle/meta/_journal.json
+++ b/packages/webapp/drizzle/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1751891704768,
       "tag": "0000_initial_schema",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1771172700000,
+      "tag": "0001_type_hardening",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/webapp/src/app/api/chatrooms/route.ts
+++ b/packages/webapp/src/app/api/chatrooms/route.ts
@@ -2,9 +2,13 @@ import { NextRequest, NextResponse } from "next/server";
 import { db } from "@/db/client";
 import { chatrooms, chatroom_members, users, messages } from "@/db/schema";
 import { auth } from "@clerk/nextjs/server";
-import { eq, inArray, count } from "drizzle-orm";
+import { eq, count } from "drizzle-orm";
+import { z } from "zod";
 
-// TODO: Import db, schema, and Clerk auth utilities
+const createChatroomSchema = z.object({
+  name: z.string().trim().min(1, "Chatroom name is required").max(80),
+  isPrivate: z.boolean().optional().default(false),
+});
 
 export async function GET(req: NextRequest) {
   try {
@@ -81,14 +85,15 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
-    const { name, isPrivate = false } = await req.json();
-
-    if (!name || name.trim().length === 0) {
+    const parseResult = createChatroomSchema.safeParse(await req.json());
+    if (!parseResult.success) {
       return NextResponse.json(
-        { error: "Chatroom name is required" },
+        { error: parseResult.error.issues[0]?.message || "Invalid request" },
         { status: 400 }
       );
     }
+
+    const { name, isPrivate } = parseResult.data;
 
     // Find the user's internal database ID
     const user = await db
@@ -104,9 +109,9 @@ export async function POST(req: NextRequest) {
     const newChatroom = await db
       .insert(chatrooms)
       .values({
-        name: name.trim(),
-        isPrivate: isPrivate ? "1" : "0", // Convert boolean to string
-        createdBy: user[0].id, // UUID
+        name,
+        isPrivate,
+        createdBy: user[0].id,
       })
       .returning();
 

--- a/packages/webapp/src/app/api/invite/[code]/route.ts
+++ b/packages/webapp/src/app/api/invite/[code]/route.ts
@@ -86,8 +86,7 @@ export async function POST(
 
     // Check maxUses if set
     if (invite[0].maxUses && invite[0].usedBy) {
-      const maxUsesNum = parseInt(invite[0].maxUses);
-      if (invite[0].usedBy.length >= maxUsesNum) {
+      if (invite[0].usedBy.length >= invite[0].maxUses) {
         return NextResponse.json(
           { error: "This invite link has reached its usage limit" },
           { status: 400 }

--- a/packages/webapp/src/db/schema.ts
+++ b/packages/webapp/src/db/schema.ts
@@ -8,6 +8,7 @@ import {
   uniqueIndex,
   uuid,
   jsonb,
+  integer,
   AnyPgColumn,
 } from "drizzle-orm/pg-core";
 
@@ -23,7 +24,7 @@ export const users = pgTable("users", {
 export const chatrooms = pgTable("chatrooms", {
   id: uuid("id").defaultRandom().primaryKey(),
   name: text("name").notNull(),
-  isPrivate: text("is_private").default("0"), // Changed from integer to text for consistency
+  isPrivate: boolean("is_private").default(false).notNull(),
   createdBy: uuid("created_by")
     .notNull()
     .references(() => users.id, { onDelete: "cascade" }),
@@ -96,5 +97,5 @@ export const chatroom_invites = pgTable("chatroom_invites", {
   createdAt: timestamp("created_at").defaultNow().notNull(),
   isActive: boolean("is_active").default(true).notNull(), // Can be deactivated manually
   usedBy: jsonb("used_by").default([]).$type<string[]>(), // Array of user IDs who used this invite
-  maxUses: text("max_uses"), // Optional limit on how many times it can be used (null = unlimited)
+  maxUses: integer("max_uses"), // Optional limit on how many times it can be used (null = unlimited)
 });

--- a/packages/webapp/src/lib/usePartySocket.ts
+++ b/packages/webapp/src/lib/usePartySocket.ts
@@ -37,7 +37,7 @@ export interface SettingsUpdateMessage {
   };
   timestamp: number;
   updatedBy: {
-    id: number;
+    id: string;
     displayName: string;
   };
   roomId: string;
@@ -47,7 +47,7 @@ export interface SettingsUpdateMessage {
 export interface MemberEventMessage {
   type: "member-joined" | "member-removed";
   member: {
-    id: number;
+    id: string;
     name: string;
     role: string;
   };


### PR DESCRIPTION
## Summary
This PR tackles the type-consistency hardening gap by aligning DB schema types and event payload contracts across API + realtime layers.

### Changes
- Convert `chatrooms.is_private` from text (`"0"/"1"`) to boolean in Drizzle schema
- Convert `chatroom_invites.max_uses` from text to integer in Drizzle schema
- Add migration `0001_type_hardening.sql` to safely convert existing values
- Add `zod` request validation for `POST /api/chatrooms`
- Update chatroom creation to persist boolean `isPrivate` directly
- Update invite usage-limit check to use integer `maxUses` directly
- Fix realtime frontend types to use UUID strings for `updatedBy.id` and `member.id`

## Why
- Removes fragile text-to-boolean and text-to-number coercions
- Reduces runtime mismatch risk between backend UUIDs and frontend event types
- Adds API boundary validation for more predictable behavior

## Notes
- I could not run project lint/tests in this environment because `bun` is not installed on the host (`bun: command not found`).
